### PR TITLE
WiFi: Ignore connectivity scans during WFD session

### DIFF
--- a/service/java/com/android/server/wifi/WifiStateMachine.java
+++ b/service/java/com/android/server/wifi/WifiStateMachine.java
@@ -3431,6 +3431,10 @@ public class WifiStateMachine extends StateMachine {
                     mTemporarilyDisconnectWifi = (message.arg1 == 1);
                     replyToMessage(message, WifiP2pServiceImpl.DISCONNECT_WIFI_RESPONSE);
                     break;
+                case WifiP2pServiceImpl.SET_MIRACAST_MODE:
+                    if (mVerboseLoggingEnabled) logd("SET_MIRACAST_MODE: " + (int)message.arg1);
+                    mWifiConnectivityManager.saveMiracastMode((int)message.arg1);
+                    break;
                 /* Link configuration (IP address, DNS, ...) changes notified via netlink */
                 case CMD_UPDATE_LINKPROPERTIES:
                     updateLinkProperties((LinkProperties) message.obj);

--- a/service/java/com/android/server/wifi/p2p/WifiP2pServiceImpl.java
+++ b/service/java/com/android/server/wifi/p2p/WifiP2pServiceImpl.java
@@ -585,6 +585,11 @@ public class WifiP2pServiceImpl extends IWifiP2pManager.Stub {
         enforceConnectivityInternalPermission();
         checkConfigureWifiDisplayPermission();
         mP2pStateMachine.sendMessage(SET_MIRACAST_MODE, mode);
+        if (mWifiChannel != null) {
+            mWifiChannel.sendMessage(WifiP2pServiceImpl.SET_MIRACAST_MODE, mode);
+        } else {
+            Log.e(TAG, "setMiracastMode(): WifiChannel is null");
+        }
     }
 
     @Override


### PR DESCRIPTION
Any scans will impact WiFi performance including WFD
performance. So during WFD session, ignore all connectivity
scans initiated internally by wifi work source.

This change will not impact any scan triggered due to user
activity and will allow those scans.

Change-Id: I6a855a8c4853a21fb0ff054c6a5155719ee12b3d
CRs-Fixed: 2136506